### PR TITLE
Update angular-scroll-animate.js

### DIFF
--- a/src/angular-scroll-animate.js
+++ b/src/angular-scroll-animate.js
@@ -40,8 +40,8 @@
  *   </file>
  * </example>
  */
-angular.module('angular-scroll-animate', []).directive('whenVisible', ['$document', '$window',
- function($document, $window) {
+angular.module('angular-scroll-animate', []).directive('whenVisible', ['$document', '$window', '$timeout',
+ function($document, $window, $timeout) {
 
     var determineWhereElementIsInViewport =
       function($el, viewportHeight, whenVisibleFn, whenNotVisibleFn, delayPercent, scope) {
@@ -116,13 +116,14 @@ angular.module('angular-scroll-animate', []).directive('whenVisible', ['$documen
         };
 
         var onScroll = function() {
+           $timeout(function () {
+            	if (!checkPending) {
+                	checkPending = true;
 
-          if (!checkPending) {
-            checkPending = true;
-
-            /* globals requestAnimationFrame */
-            requestAnimationFrame(updateVisibility);
-          }
+        			/* globals requestAnimationFrame */
+            		requestAnimationFrame(updateVisibility);
+          		}
+			});
         };
 
         var documentListenerEvents = 'scroll';


### PR DESCRIPTION
I had to add this $timeout in order to wait for my elements to be ready. Without this $timeout, sometimes elements that were already on screen and had the scroll directive wouldn't appear, since their position were not right since they were not ready.

In my case, to reproduce this you simply have an element with the directive and it needs to bee fully appearing on screen. I don't know if this is the best place for the $timeout to be, but it worked for me.

I hope it helps.

![screen shot 2015-12-09 at 8 52 06 pm](https://cloud.githubusercontent.com/assets/4381945/11701482/e2d61414-9eb6-11e5-9ee4-839d39ae306f.png)
![screen shot 2015-12-09 at 8 53 00 pm](https://cloud.githubusercontent.com/assets/4381945/11701483/e2d7d24a-9eb6-11e5-90ca-37fde8ce1d82.png)
